### PR TITLE
Added transparent support for CDMA iPhones

### DIFF
--- a/iPhoneTracking.xcodeproj/project.pbxproj
+++ b/iPhoneTracking.xcodeproj/project.pbxproj
@@ -195,7 +195,6 @@
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "iPhoneTracking" */;
 			compatibilityVersion = "Xcode 3.1";
-			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
 				English,

--- a/iPhoneTrackingAppDelegate.m
+++ b/iPhoneTrackingAppDelegate.m
@@ -149,18 +149,13 @@
   const float precision = 100;
   NSMutableDictionary* buckets = [NSMutableDictionary dictionary];
 
-  // Default query is for GSM iPhone
-  NSString* queries[] = {@"SELECT * FROM CellLocation;", @"SELECT * FROM WifiLocation;"};
-
-  // Determine if CDMA or GSM iPhone.
-  BOOL isCDMAiPhone = [database tableExists:@"CdmaCellLocation"];
-  if (isCDMAiPhone) {
-	//  Adjust first query for CDMA Cell Locations
-	queries[0] = @"SELECT * from CdmaCellLocation;";	
-  }	
+  NSString* queries[] = {
+		@"SELECT * FROM CellLocation;", // GSM iPhone
+		@"SELECT * FROM CdmaCellLocation;", // CDMA iPhone
+	    @"SELECT * FROM WifiLocation;"};
 	
   // Temporarily disabled WiFi location pulling, since it's so dodgy. Change to 
-  for (int pass=0; pass<1; /*pass<2;*/ pass+=1) {
+  for (int pass=0; pass<2; /*pass<3;*/ pass+=1) {
   
     FMResultSet* results = [database executeQuery:queries[pass]];
 

--- a/iPhoneTrackingAppDelegate.m
+++ b/iPhoneTrackingAppDelegate.m
@@ -149,8 +149,16 @@
   const float precision = 100;
   NSMutableDictionary* buckets = [NSMutableDictionary dictionary];
 
+  // Default query is for GSM iPhone
   NSString* queries[] = {@"SELECT * FROM CellLocation;", @"SELECT * FROM WifiLocation;"};
-  
+
+  // Determine if CDMA or GSM iPhone.
+  BOOL isCDMAiPhone = [database tableExists:@"CdmaCellLocation"];
+  if (isCDMAiPhone) {
+	//  Adjust first query for CDMA Cell Locations
+	queries[0] = @"SELECT * from CdmaCellLocation;";	
+  }	
+	
   // Temporarily disabled WiFi location pulling, since it's so dodgy. Change to 
   for (int pass=0; pass<1; /*pass<2;*/ pass+=1) {
   


### PR DESCRIPTION
Thanks for writing this. Very interesting.

I have a CDMA iPhone (Verizon) and the CellLocation table is called CdmaCellLocation on these devices. I simply added very simple check to determine if the table exists, and if so, to use that table instead. 

I would appreciate a  GSM user to verify that this table does NOT exist on GSM databases.

Feel free to contact me via e-mail at: wclarkso@cs.princeton.edu
