### PR TITLE
Log the found filename in Console

### DIFF
--- a/iPhoneTrackingAppDelegate.m
+++ b/iPhoneTrackingAppDelegate.m
@@ -116,6 +116,8 @@
       if (dbFileName==nil) {
         NSLog(@"No consolidated.db file found in '%@'", newestFolder);
         continue;
+      } else {
+          NSLog(@"File found at '%@'", dbFileName);
       }
 
       NSString* dbFilePath = [newestFolder stringByAppendingPathComponent:dbFileName];


### PR DESCRIPTION
It's useful to use this application just to locate the SQLite file - here's a patch that logs it to the Console. There could obviously be a bigger implementation, like showing this in an interface element, but as a stopgap, this worked for me.
